### PR TITLE
Clean up the memory benchmark scripts and add a couple more for conve…

### DIFF
--- a/memcpy-benchmarks/count-top-funcs.sh
+++ b/memcpy-benchmarks/count-top-funcs.sh
@@ -11,25 +11,36 @@ set -u
 
 usage () {
     cat <<EOF
-Usage ./count-top-funcs.sh : Count frequency of most use functions
-          [--resdir <dir>] : Directory with the results.  Default
-                             "res-baseline"
-          [--total|--self] : Select results based on total (self + children)
-                             or just self.  Default "total"`
-          [--md | --csv]   : Output results in Markdown (default) or CSV
+Usage ./count-top-funcs.sh       : Count frequency of most use functions
+          [--resdir <dir>]       : Directory with the results.  Default
+                                   "res-baseline"
+          [--total|--self]       : Select results based on total (self +
+                                   children) or just self.  Default "total"
+          [--types <list>]       : List of result file types, default
+                                   "scalar vector-small vector-large"
+          [--cutoff <val>]       : Cutoff for count to be presented.  Default 0
+          [--md | --csv | --raw] : Output results in Markdown, CSV or as a raw
+                                   string for use as the --funclist argument
+                                   of profile-all-funcs.sh
 
 The results to be analysed will be in files of the form
-"prof-<type>-<size>.res", where type is one of "scalar", "vector-small" or
-"vector-large", and size, is the size of the data block in bytes copied on
+"prof-<type>-<size>.res", where type is one of the types listed in the
+--types argument, and size, is the size of the data block in bytes copied on
 each iteration.
 EOF
 }
 
-topdir="$(cd $(dirname $(dirname $(dirname $(readlink -f $0)))) ; pwd)"
-memcpydir="${topdir}/tooling/memcpy-benchmarks"
+# Directories
+tooldir="$(cd $(dirname $(dirname $(readlink -f $0))) ; pwd)"
+topdir="$(cd $(dirname ${tooldir}) ; pwd)"
+memcpydir="${tooldir}/memcpy-benchmarks"
+
+# Defaults
 resdir="${memcpydir}/res-baseline"
 dototal="--total"
-format="--md"
+types="scalar vector-small vector-large"
+cutoff="0"
+format="--raw"
 
 set +u
 until
@@ -43,7 +54,15 @@ until
       --total|--self)
 	  dototal=$1
 	  ;;
-      --md|--csv)
+      --types)
+	  shift
+	  types="$1"
+	  ;;
+      --cutoff)
+	  shift
+	  cutoff="$1"
+	  ;;
+      --md|--csv|--raw)
 	  format="$1"
 	  ;;
       --help)
@@ -66,25 +85,28 @@ set -u
 # We create a lot of temporaries!
 tmpdir="$(mktemp -d count-top-funcs-XXXXXX)"
 
-# Find out the sizes
-dlens="$(ls -1 ${resdir}/prof-scalar-*.res | \
-	    sed -e 's/^.*prof-scalar-//' -e 's/\.res$//' | sort -n)"
-
 cd ${memcpydir}
-for tp in "scalar" "vector-small" "vector-large"
+for tp in ${types}
 do
-    echo
-    echo "${tp}"
-    echo
     tmpf1="${tmpdir}/all-${tp}.res"
     tmpf2="${tmpdir}/table-${tp}.res"
     rm -f "${tmpf1}"
     touch "${tmpf1}"
+
+    # Find out the sizes
+    dlens=$(ls -1 ${resdir}/prof-${tp}-*.res | \
+		sed -e "s/^.*prof-${tp}-//" -e 's/\.res$//' | sort -n)
+    nlens=$(echo "${dlens}" | wc -l)
+    printf "%s %d results\n" "${tp}" "${nlens}"
+
+    # Extract all the desired data
     for l in ${dlens}
     do
+	echo -n "."
 	./extract-top-level-funcs.sh --resfile ${resdir}/prof-${tp}-${l}.res \
 				     ${dototal} --omit-empty >> ${tmpf1}
     done
+    echo
     sed -n < ${tmpf1} -e 's/`//gp' | \
 	sed -e 's/^|[^|]*|[^|]*| //' -e 's/[[:space:]]*|$//' | \
 	sort | uniq -c | sort -nr > ${tmpf2}
@@ -100,9 +122,15 @@ do
 	    printf '"%s","%s"\n' "Count" "Function/address"
     esac
 
+    funclist=
     while IFS='' read -r line
     do
 	cnt=$(echo "${line}" | sed -e 's/^[[:space:]]\+//' -e 's/ .*$//')
+	if [[ "${cnt}" -lt "${cutoff}" ]]
+	then
+	    break
+	fi
+
 	func=$(echo "${line}" | \
 		   sed -e 's/^[[:space:]]\+[[:digit:]]\+[[:space:]]\+//')
 
@@ -114,8 +142,21 @@ do
 		;;
 	    --csv)
 		printf '"%s","%s"\n' "${cnt}" "${func}"
+		;;
+	    --raw)
+		if [[ "x${funclist}" == "x" ]]
+		then
+		    funclist="${func}"
+		else
+		    funclist="${funclist} ${func}"
+		fi
 	esac
     done < ${tmpf2}
+
+    if [[ "${format}" == "--raw" ]]
+    then
+	printf '"%s"\n' "${funclist}"
+    fi
 done
 
 rm -r ${tmpdir}

--- a/memcpy-benchmarks/run-all.sh
+++ b/memcpy-benchmarks/run-all.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Copyright (C) 2024 Embecosm Limited <www.embecosm.com>
+# Contributor Jeremy Bennett <jeremy.bennett@embecosm.com>
+
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# A script to do multiple performance profiling runs
+
+tooldir="$(cd $(dirname $(dirname $(readlink -f $0))) ; pwd)"
+topdir="$(cd $(dirname ${tooldir}) ; pwd)"
+memcpydir="${tooldir}/memcpy-benchmarks"
+qemudir=${topdir}/qemu
+
+logfile=${memcpydir}/run-all.log
+rm -f ${logfile}
+touch ${logfile}
+
+ids="ef9e258b94376c5017b4df9fe061abcadc9661f2 \
+     7809b7fafbc24c557751a1845bb1ccc0b9376f90"
+
+export PATH=${topdir}/install/bin:${PATH}
+which qemu-riscv64 2>&1 | tee -a ${logfile}
+
+# Build all the programs to benchmark
+cd ${memcpydir}
+make
+
+# Now do the profiling
+for c in ${ids}
+do
+    resfile="${memcpydir}/results-${c}"
+    echo "Checking out QEMU commit ${c}..." 2>&1 | tee -a ${logfile}
+    date 2>&1 | tee -a ${logfile}
+    pushd ${qemudir} > /dev/null 2>&1
+    git checkout ${c} 2>&1 | tee -a ${logfile}
+    popd > /dev/null 2>&1
+
+    echo "Building QEMU for commit ${c}..." 2>&1 | tee -a ${logfile}
+    date 2>&1 | tee -a ${logfile}
+    pushd ${tooldir} > /dev/null 2>&1
+    ./build-all.sh --qemu-only --clean-qemu --qemu-cflags "-g" \
+		   --qemu-configs "--disable-plugins" 2>&1 | tee -a ${logfile}
+    popd > /dev/null 2>&1
+
+    echo "Running perf for commit ${c}..." 2>&1 | tee -a ${logfile}
+    date 2>&1 | tee -a ${logfile}
+    pushd ${memcpydir} > /dev/null 2>&1
+    mkdir -p "${resfile}"
+    ./run-perf.sh 2>&1 | tee -a ${logfile}
+
+    echo "Putting results in ${resfile}..." 2>&1 | tee -a ${logfile}
+    mv prof-*.res "${resfile}"
+    date 2>&1 | tee -a ${logfile}
+    popd > /dev/null 2>&1
+done

--- a/memcpy-benchmarks/run-memcpy.sh
+++ b/memcpy-benchmarks/run-memcpy.sh
@@ -182,26 +182,26 @@ if [[ $lmul != "1" ]]
 then
   if [[ ${format} == "--md" ]]
   then
-      printf "| %5d | %6d | %7.2f | %7.2f | %7.2f | %10.1f | %10.1f | %10.1f | %10.2f | %10.2f | %10.2f |\n" \
-	   ${vlen} $length $scalar_time $vector1_time $vectorM_time \
-	   ${scalar_micount} ${vector1_micount} ${vectorM_micount} \
-	   ${scalar_nspi} ${vector1_nspi} ${vectorM_nspi}
+      printf "| %10d | %5d | %6d | %7.2f | %7.2f | %7.2f | %10.1f | %10.1f | %10.1f | %10.2f | %10.2f | %10.2f |\n" \
+	     ${iterations} ${vlen} $length $scalar_time $vector1_time \
+	     $vectorM_time ${scalar_micount} ${vector1_micount} \
+	     ${vectorM_micount} ${scalar_nspi} ${vector1_nspi} ${vectorM_nspi}
   else
-      printf "\"%d\",\"%d\",\"%.2f\",\"%.2f\",\"%.2f\",\"%.1f\",\"%.1f\",\"%.1f\",\"%.2f\",\"%.2f\",\"%.2f\"\n" \
-	   ${vlen} $length $scalar_time $vector1_time $vectorM_time \
-	   ${scalar_micount} ${vector1_micount} ${vectorM_micount} \
-	   ${scalar_nspi} ${vector1_nspi} ${vectorM_nspi}
+      printf "\"%d\",\"%d\",\"%d\",\"%.2f\",\"%.2f\",\"%.2f\",\"%.1f\",\"%.1f\",\"%.1f\",\"%.2f\",\"%.2f\",\"%.2f\"\n" \
+	     ${iterations} ${vlen} $length $scalar_time $vector1_time \
+	     $vectorM_time ${scalar_micount} ${vector1_micount} \
+             ${vectorM_micount} ${scalar_nspi} ${vector1_nspi} ${vectorM_nspi}
   fi
 else
   if [[ ${format} == "--md" ]]
   then
-      printf "| %5d | %6d | %7.2f | %7.2f | %10.1f | %10.1f | %10.2f | %10.2f |\n" \
-	   ${vlen} $length $scalar_time $vector1_time \
+      printf "| %10d | %5d | %6d | %7.2f | %7.2f | %10.1f | %10.1f | %10.2f | %10.2f |\n" \
+	   ${iterations} ${vlen} $length $scalar_time $vector1_time \
 	   ${scalar_micount} ${vector1_micount} \
 	   ${scalar_nspi} ${vector1_nspi}
   else
-      printf "\"%d\",\"%d\",\"%.2f\",\"%.2f\",\"%.1f\",\"%.1f\",\"%.2f\",\"%.2f\"\n" \
-	   ${vlen} $length $scalar_time $vector1_time \
+      printf "\"%d\",\"%d\",\"%d\",\"%.2f\",\"%.2f\",\"%.1f\",\"%.1f\",\"%.2f\",\"%.2f\"\n" \
+	   ${iterations} ${vlen} $length $scalar_time $vector1_time \
 	   ${scalar_micount} ${vector1_micount} \
 	   ${scalar_nspi} ${vector1_nspi}
   fi

--- a/memcpy-benchmarks/run-perf.sh
+++ b/memcpy-benchmarks/run-perf.sh
@@ -14,8 +14,7 @@ usage () {
 Usage: ./run-perf.sh       : Run Linux perf on memcpy benchmarks
           [--bytes <num>]  : Total bytes to copy.  Default 1,000,000,000
           [--resdir <dir>] : Directory in which to place the results.  Default
-                             is "res-baseline" in the directory holding this
-			     script.
+                             is the directory holding this script.
           [--sizes <list>] : Space separated list of the data sizes to use when
                              creating results.  Default list is all the powers
                              of 2, 3, 5 and 7 up to 5^6
@@ -34,11 +33,11 @@ accurate results, but is slow.  Expect each iteration to take of the order of
 EOF
 }
 
-memcpydir="$(cd $(readlink -f $0) ; pwd)"
+memcpydir="$(cd $(dirname $(readlink -f $0)) ; pwd)"
 
 # Default values
 bytes="1000000000"
-resdir="${memcpydir}/res-baseline"
+resdir="${memcpydir}"
 data_lens="  1 \
              2 \
              3 \
@@ -104,6 +103,8 @@ do
   shift
 done
 set -u
+
+mkdir -p "${resdir}"
 
 for dlen in ${data_lens}
 do

--- a/memcpy-benchmarks/run-sequence-all.sh
+++ b/memcpy-benchmarks/run-sequence-all.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Copyright (C) 2024 Embecosm Limited <www.embecosm.com>
+# Contributor Jeremy Bennett <jeremy.bennett@embecosm.com>
+
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# A script to do multiple sequence runs
+
+tooldir="$(cd $(dirname $(dirname $(readlink -f $0))) ; pwd)"
+topdir="$(cd $(dirname ${tooldir}) ; pwd)"
+memcpydir="${tooldir}/memcpy-benchmarks"
+qemudir=${topdir}/qemu
+
+logfile=${memcpydir}/run-all.log
+rm -f ${logfile}
+touch ${logfile}
+
+# Baseline, prev best, new best
+ids="7bbadc60b58b742494555f06cd342311ddab9351 \
+     ef9e258b94376c5017b4df9fe061abcadc9661f2 \
+     7809b7fafbc24c557751a1845bb1ccc0b9376f90"
+
+export PATH=${topdir}/install/bin:${PATH}
+which qemu-riscv64 2>&1 | tee -a ${logfile}
+
+# Build all the programs to benchmark
+cd ${memcpydir}
+make 2>&1 | tee -a ${logfile}
+
+# Now do the profiling
+for c in ${ids}
+do
+    csvfile="${memcpydir}/seq-results-${c}.csv"
+    echo "Checking out QEMU commit ${c}..." 2>&1 | tee -a ${logfile}
+    date 2>&1 | tee -a ${logfile}
+    pushd ${qemudir} > /dev/null 2>&1
+    git checkout ${c} >> ${logfile} 2>&1
+    popd > /dev/null 2>&1
+
+    echo "Building QEMU for commit ${c}..." 2>&1 | tee -a ${logfile}
+    date 2>&1 | tee -a ${logfile}
+    pushd ${tooldir} > /dev/null 2>&1
+    ./build-all.sh --qemu-only --clean-qemu >> ${logfile} 2>&1
+    popd > /dev/null 2>&1
+
+    echo "Running sequence for commit ${c}..." 2>&1 | tee -a ${logfile}
+    date 2>&1 | tee -a ${logfile}
+    pushd ${memcpydir} > /dev/null 2>&1
+    ./run-sequence.sh --iter "100000000" --csv  > ${csvfile} 2>&1
+    echo "Results in ${csvfile}" | tee -a ${logfile}
+    date 2>&1 | tee -a ${logfile}
+done

--- a/memcpy-benchmarks/vmemcpy-main.c
+++ b/memcpy-benchmarks/vmemcpy-main.c
@@ -90,4 +90,3 @@ main (int argc, char* argv[])
   free(dst);
 
 }
-


### PR DESCRIPTION
…nience.

In general we make the scripts a bit more flexible, removing fixed names and adding some more output formats.  There are also two more scripts to run full sets of profiling and memory copying benchmarks.

memcpy-benchmarks/

	* count-top-funcs.sh: Give flexibility in the variants to be counted and add a cutoff option; allow a raw output format, so the results can be used in profile-all-funcs.sh.
	* extract-top-level-funcs.sh: Add some more sorting of results.
	* profile-all-funcs.sh: Sort results by function name.
	* run-all.sh: Created.
	* run-memcpy.sh: Small cleanups.
	* run-perf.sh: Likewise.
	* run-sequence-all.sh: Created.
	* run-sequence.sh: More options to configure sequence, scale iterations by size of block, output number of iterations used.
	* vmemcpy-main.c: Remove a blank line.