### PR TITLE
Cleanup SiFive benchmarking

### DIFF
--- a/strmem-benchmarks/README.md
+++ b/strmem-benchmarks/README.md
@@ -26,6 +26,7 @@ To run the benchmarking script you will need:
 - Python 3.10 or later
 - Gnuplot 5 or later
 - Pandoc 2.9 or later
+- csvtool (needed for plotting)
 
 ## About the benchmarksing
 
@@ -55,7 +56,7 @@ problem size, one line for the "baseline" version of QEMU, the other the
 Ensure a standard GCC 14.1 tool chain is on your path.  You can then run the
 benchmarks and generate a PDF report using the following:
 ```
-./run-all-benchmarks.py --qemulist <commit> <commit>
+./run_all_benchmarks.py --qemulist <commit> <commit>
 ```
 Where the arguments are two commits of QEMU you wish to compare, with the
 first being presented in the report as the "baseline".  There are numerous

--- a/strmem-benchmarks/parseargs.py
+++ b/strmem-benchmarks/parseargs.py
@@ -13,7 +13,6 @@ A module to parse arguments for the SiFive benchmarks
 """
 
 import argparse
-import logging
 import os
 import os.path
 import sys
@@ -48,18 +47,18 @@ class ParseArgs:
         # When we run
         datestamp = time.strftime('%Y-%m-%d-%H-%M-%S')
         # Some default lists (and choices) for convenience
-        BMLIST_DFT = ['memchr', 'memcmp', 'memcpy', 'memmove', 'memset',
+        bmlist_dft = ['memchr', 'memcmp', 'memcpy', 'memmove', 'memset',
                       'strcat', 'strchr', 'strcmp', 'strcpy', 'strlen',
                       'strncat', 'strncmp', 'strncpy', 'strnlen',]
-        SIZELIST_DFT = [    1,     2,     3,     4,     5,     7,
+        sizelist_dft = [    1,     2,     3,     4,     5,     7,
                             8,     9,    11,    16,    25,    27,
                            32,    49,    64,    81,   121,   125,
                           128,   243,   256,   343,   512,   625,
                           729,  1024,  1331,  2048,  2401,  3125,
                          4096,  6561,  8192, 14641, 15625, 16384,
                         16807, 19683, 32768, 59049, 65536, 78125,]
-        CONFLIST_DFT = ['stdlib', '128-1', '1024-8']
-        CONFLIST_CHOICES = ['stdlib',
+        conflist_dft = ['stdlib', '128-1', '1024-8']
+        conflist_choices = ['stdlib',
                              '128-1',  '128-2',  '128-4',  '128-8',
                              '256-1',  '256-2',  '256-4',  '256-8',
                              '512-1',  '512-2',  '512-4',  '512-8',
@@ -113,7 +112,8 @@ class ParseArgs:
             type=str,
             default=installdir_dft,
             metavar='DIR',
-            help='Main directory for installing programs for the benchmarking (default: %(default)s)',
+            help='Main directory for installing programs ' \
+                 'for the benchmarking (default: %(default)s)',
         )
         parser.add_argument(
             '--sifivesrcdir',
@@ -132,9 +132,9 @@ class ParseArgs:
         parser.add_argument(
             '--bmlist',
             type=str,
-            default=BMLIST_DFT,
+            default=bmlist_dft,
             nargs='*',
-            choices=BMLIST_DFT,
+            choices=bmlist_dft,
             metavar='BENCHMARK',
             help='Benchmarks to run (default: %(default)s)',
         )
@@ -203,7 +203,7 @@ class ParseArgs:
         parser.add_argument(
             '--sizelist',
             type=int,
-            default=SIZELIST_DFT,
+            default=sizelist_dft,
             nargs='*',
             metavar='NUM',
             help='Sizes of data to use (default: %(default)s)',
@@ -211,9 +211,9 @@ class ParseArgs:
         parser.add_argument(
             '--conflist',
             type=str,
-            default=CONFLIST_DFT,
+            default=conflist_dft,
             nargs='*',
-            choices=CONFLIST_CHOICES,
+            choices=conflist_choices,
             metavar='VLEN-LMUL',
             help='VLEN-LMUL configurations to run (default: %(default)s)',
         )

--- a/strmem-benchmarks/plot-one-benchmark.sh
+++ b/strmem-benchmarks/plot-one-benchmark.sh
@@ -51,7 +51,7 @@ find_max () {
 
 # Function to run its argument under python
 runpy () {
-    echo "${1}" | python
+    echo "${1}" | python3
 }
 
 # Find an appropriate range for the supplied argument. Add 20% and then 

--- a/strmem-benchmarks/run_all_benchmarks.py
+++ b/strmem-benchmarks/run_all_benchmarks.py
@@ -14,15 +14,12 @@
 It is based on a generic Embecosm framework for such benchmarking.
 """
 
-import concurrent.futures
-import os
 import sys
 
 from support import Log
 from support import check_python_version
 from parseargs import ParseArgs
 from qemutools import QEMUBuilder
-from modeling import Model
 from modeling import ModelSet
 from reporting import Reporter
 
@@ -46,7 +43,7 @@ def main():
         res.generate_csv()
     # Report the results
     rpt = Reporter(ModelSet, args, log)
-    rpt.genReport()
+    rpt.gen_report()
 
 # Make sure we have new enough Python and only run if this is the main package
 check_python_version(3, 10)

--- a/strmem-benchmarks/support.py
+++ b/strmem-benchmarks/support.py
@@ -16,7 +16,6 @@ Benchmarking common procedures.
 import logging
 import os
 import sys
-import time
 
 
 # What we export
@@ -24,7 +23,6 @@ import time
 __all__ = [
     'Log',
     'check_python_version',
-    'arglist_to_str',
 ]
 
 
@@ -34,10 +32,9 @@ class Log:
         self.__log = logging.getLogger()
 
     def __create_logdir(self, logdir):
-        """Create the log directory, which can be relative to the root directory
-           or absolute"""
+        """Create the log directory, which we make absolute"""
         if not os.path.isabs(logdir):
-            logdir = os.path.join(gp['rootdir'], logdir)
+            logdir = os.path.abspath(logdir)
 
             if not os.path.isdir(logdir):
                 try:
@@ -74,23 +71,28 @@ class Log:
         self.__log.addHandler(file_h)
 
         # Log where the log file is
-        self.__log.debug(f'Log file: {logfile}\n')
+        self.__log.debug('Log file: %s', logfile)
         self.__log.debug('')
 
-    def critical(self, str):
-        self.__log.critical(str)
+    def critical(self, *args):
+        """Wrapper for the underlying log critical method."""
+        self.__log.critical(*args)
 
-    def error(self, str):
-        self.__log.error(str)
+    def error(self, *args):
+        """Wrapper for the underlying log error method."""
+        self.__log.error(*args)
 
-    def warning(self, str):
-        self.__log.warning(str)
+    def warning(self, *args):
+        """Wrapper for the underlying log warning method."""
+        self.__log.warning(*args)
 
-    def info(self, str):
-        self.__log.info(str)
+    def info(self, *args):
+        """Wrapper for the underlying log info method."""
+        self.__log.info(*args)
 
-    def debug(self, str):
-        self.__log.debug(str)
+    def debug(self, *args):
+        """Wrapper for the underlying log debug method."""
+        self.__log.debug(*args)
 
 
 # Make sure we have new enough python.  This is will predate logging being set
@@ -102,38 +104,3 @@ def check_python_version(major, minor):
         print(f'ERROR: Requires Python {major}.{minor} or later',
               file=sys.stderr)
         sys.exit(1)
-
-def log_args(args):
-    """Record all the argument values"""
-    log.debug('Supplied arguments')
-    log.debug('==================')
-
-    for arg in vars(args):
-        realarg = re.sub('_', '-', arg)
-        val = getattr(args, arg)
-        log.debug('--{arg:20}: {val}'.format(arg=realarg, val=val))
-
-    log.debug('')
-
-
-def log_benchmarks(benchmarks):
-    """Record all the benchmarks in the log"""
-    log.debug('Benchmarks')
-    log.debug('==========')
-
-    for bench in benchmarks:
-        log.debug(bench)
-
-    log.debug('')
-
-
-def arglist_to_str(arglist):
-    """Make arglist into a string"""
-
-    for arg in arglist:
-        if arg == arglist[0]:
-            str = arg
-        else:
-            str = str + ' ' + arg
-
-    return str


### PR DESCRIPTION
These are just tidying up of the Python code after checking by pylint.

	* README.md: Change name of script.
	* modeling.py: Linting cleanups.
	* parseargs.py: Likewise.
	* plot-one-benchmark.sh: Use Python3 explicitly.
	* qemutools.py: Change name of script.
	* reporting.py: Likewise.
	* run_all_benchmarks.py: Renamed from run-all-benchmarks.py.
	* support.py: Change name of script.