### PR TITLE
Allow the user to specify the maximum number of parallel processes.

### DIFF
--- a/strmem-benchmarks/modeling.py
+++ b/strmem-benchmarks/modeling.py
@@ -404,7 +404,8 @@ class ModelSet:
         resf = {}
         # Launch all the builds
         self._log.info('Building all model configurations')
-        with concurrent.futures.ProcessPoolExecutor() as executor:
+        with concurrent.futures.ProcessPoolExecutor(
+                max_workers=self._args.get('jobs')) as executor:
             for m in self._model_list:
                 resf[m] = executor.submit (m.build)
 
@@ -449,7 +450,8 @@ class ModelSet:
         # Launch all the builds
         self._log.info('Running all model configurations')
         resf = {}
-        with concurrent.futures.ProcessPoolExecutor() as executor:
+        with concurrent.futures.ProcessPoolExecutor(
+                max_workers=self._args.get('jobs')) as executor:
             for m in self._model_list:
                 resf[m] = executor.submit (m.run)
 

--- a/strmem-benchmarks/parseargs.py
+++ b/strmem-benchmarks/parseargs.py
@@ -13,6 +13,7 @@ A module to parse arguments for the SiFive benchmarks
 """
 
 import argparse
+import multiprocessing
 import os
 import os.path
 import sys
@@ -251,6 +252,13 @@ class ParseArgs:
             action='store_true',
             default=False,
             help='Only prepare a report from existing results (default: %(default)s)'
+        )
+        parser.add_argument(
+            '--jobs', '-j',
+            type=int,
+            default=multiprocessing.cpu_count(),
+            metavar='PROCS',
+            help='Number of parallel processes to use (default: %(default)s)',
         )
         parser.add_argument(
             '--timeout',

--- a/strmem-benchmarks/qemutools.py
+++ b/strmem-benchmarks/qemutools.py
@@ -182,7 +182,7 @@ class QEMUBuilder:
            is 'plugin' or 'no-plugin'."""
         dmess = 'DEBUG: Building QEMU'
         self._log.debug(f'{dmess} commit {self.cmt} {plt} version')
-        nprocs=str(multiprocessing.cpu_count())
+        nprocs=str(self._args.get('jobs'))
         cmd = f'make -j {nprocs}'
         try:
             res = subprocess.run(


### PR DESCRIPTION
	* modeling.py (ModelSet:build ModelSet:run): specify max_workers from args when creating Executor.
	* parseargs.py (ParseArgs:build_parser): Add options '-j'/'--jobs' to specify maximum number of processors.
	* qemutools.py (QEMUBuilder:_build): Specify maximum jobs when building from args.